### PR TITLE
KAH-5 ( map triggers endpoints tests )

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -72,6 +72,8 @@ private.ts
 /server/libs/plugins/*
 /server/tmp
 /console/env.json
+/server/config.json
+/server/dbdir
 
 #centOs
 *.service

--- a/server/api/tests/factories/test-data-manager.js
+++ b/server/api/tests/factories/test-data-manager.js
@@ -83,7 +83,8 @@ module.exports = class TestDataManager {
         }
 
         try {
-            this.collection = await this.currentMongooseModel.insertMany(generatedData);
+            this.collection = await this.currentMongooseModel.insertMany(generatedData, {ordered: true});
+            console.log(this.collection);
             return this.collection;
         } catch (err) {
             throw err;

--- a/server/api/tests/factories/test-data-manager.js
+++ b/server/api/tests/factories/test-data-manager.js
@@ -84,7 +84,6 @@ module.exports = class TestDataManager {
 
         try {
             this.collection = await this.currentMongooseModel.insertMany(generatedData, {ordered: true});
-            console.log(this.collection);
             return this.collection;
         } catch (err) {
             throw err;

--- a/server/api/tests/factories/test-data-manager.js
+++ b/server/api/tests/factories/test-data-manager.js
@@ -83,7 +83,7 @@ module.exports = class TestDataManager {
         }
 
         try {
-            this.collection = await this.currentMongooseModel.insertMany(generatedData, {ordered: false});
+            this.collection = await this.currentMongooseModel.insertMany(generatedData);
             return this.collection;
         } catch (err) {
             throw err;

--- a/server/api/tests/factories/triggers.factory.js
+++ b/server/api/tests/factories/triggers.factory.js
@@ -30,6 +30,7 @@ const actionParamsSchema = {
     }
 };
 
+
 const triggerSchema = {
     type: 'object',
     properties: {
@@ -38,10 +39,8 @@ const triggerSchema = {
             format: 'mongoID'
         },
         name: {
-            type: {
-                type: 'string',
-                faker: 'random.word'
-            }
+            type: 'string',
+            faker: 'random.word'
         },
         map: {
             type: "string",
@@ -66,7 +65,9 @@ const triggerSchema = {
             type: 'string',
             faker: 'random.word'
         },
-        params: [actionParamsSchema],
+        params: {
+            $ref: actionParamsSchema
+        }
     },
     required: ['_id', 'name', 'map']
 };
@@ -75,8 +76,7 @@ const triggerCollectionSchema = {
     type: 'array',
     items: triggerSchema,
     maxItems: 15,
-    minItems: 5,
-    uniqueItems: 'key'
+    minItems: 5
 };
 
 module.exports = {

--- a/server/api/tests/factories/triggers.factory.js
+++ b/server/api/tests/factories/triggers.factory.js
@@ -40,7 +40,11 @@ const triggerSchema = {
         },
         name: {
             type: 'string',
-            faker: 'random.word'
+            chance: {
+                word: {
+                    length: 10
+                }
+            }
         },
         map: {
             type: "string",

--- a/server/api/tests/factories/triggers.factory.js
+++ b/server/api/tests/factories/triggers.factory.js
@@ -1,0 +1,86 @@
+const { jsf } = require('./jsf.helper');
+
+jsf.option({
+    useDefaultValue: true,
+});
+
+const actionParamsSchema = {
+    type: 'object',
+    properties: {
+        value: {
+            type: 'string',
+            faker: 'random.word'
+        },
+        viewName: {
+            type: 'string',
+            faker: 'random.word'
+        },
+        param: {
+            type: 'string',
+            faker: 'random.word'
+        },
+        name: {
+            type: 'string',
+            faker: 'random.word'
+        },
+        type: {
+            type: 'string',
+            faker: 'random.word'
+        }
+    }
+};
+
+const triggerSchema = {
+    type: 'object',
+    properties: {
+        _id: {
+            type: 'string',
+            format: 'mongoID'
+        },
+        name: {
+            type: {
+                type: 'string',
+                faker: 'random.word'
+            }
+        },
+        map: {
+            type: "string",
+            format: 'mongoID',
+            default: '5d70c6f15556a11f1860bc6e'
+        },
+        description: {
+            type: 'string',
+            faker: 'lorem.paragraph'
+        },
+        createdAt: { type: 'string', faker: 'date.recent' },
+        active: { type: 'boolean', faker: 'random.boolean' },
+        plugin: {
+            type: 'string',
+            faker: 'random.word'
+        },
+        method: {
+            type: 'string',
+            faker: 'random.word'
+        },
+        configuration: {
+            type: 'string',
+            faker: 'random.word'
+        },
+        params: [actionParamsSchema],
+    },
+    required: ['_id', 'name', 'map']
+};
+
+const triggerCollectionSchema = {
+    type: 'array',
+    items: triggerSchema,
+    maxItems: 15,
+    minItems: 5,
+    uniqueItems: 'key'
+};
+
+module.exports = {
+    generateTriggerCollection: (options) => jsf.generate(Object.assign(triggerCollectionSchema, options)),
+    generateTriggerDocument: (options) => jsf.generate(Object.assign(triggerSchema, options)),
+    mapId: triggerSchema.properties.map.default
+};

--- a/server/api/tests/map-triggers.test.js
+++ b/server/api/tests/map-triggers.test.js
@@ -1,0 +1,130 @@
+const request = require('supertest');
+
+const app = require('../../app');
+const mapId = '5d70c6f15556a11f1860bc6e';
+let triggerId = '5d720cabd990b82430dcf60a';
+
+describe('Map triggers tests', () => {
+  describe('Positive', () => {
+
+    beforeEach((done) => {
+      request(app)
+        .post(`/api/triggers/${mapId}`)
+        .send({ name: 'beforeEach trigger' })
+        .end(function (err, res) {
+          triggerId = res.body.id;
+          done();
+        });
+    })
+
+    afterEach((done) => {
+      request(app)
+        .delete(`/api/triggers/${mapId}/${triggerId}`)
+        .end(function (err, res) {
+          done();
+        });
+    })
+
+    describe(`GET /:mapId`, () => {
+      it(`should respond with a list of triggers`, function (done) {
+        request(app)
+          .get(`/api/triggers/${mapId}`)
+          .expect(200)
+          .end(function (err, res) {
+            expect(Array.isArray(res.body)).toBe(true);
+            done();
+          });
+      });
+    });
+
+    describe(`POST /:mapId`, () => {
+      it(`should respond with a created trigger`, function (done) {
+        const triggerName = 'test trigger name';
+        request(app)
+          .post(`/api/triggers/${mapId}`)
+          .send({ name: triggerName })
+          .expect(200)
+          .end(function (err, res) {
+            expect(res.body.name).toEqual(triggerName);
+            done();
+          });
+      });
+    });
+
+    describe(`DELETE /:mapId/:triggerId`, () => {
+      it(`should respond with 'OK'`, function (done) {
+        request(app)
+          .delete(`/api/triggers/${mapId}/${triggerId}`)
+          .expect(200)
+          .end(function (err, res) {
+            expect('OK');
+            done();
+          });
+      });
+    });
+
+    describe(`PUT /:mapId/:triggerId`, () => {
+      it(`should respond with an updated trigger`, function (done) {
+        const newTriggerName = 'test trigger name 2';
+        request(app)
+          .put(`/api/triggers/${mapId}/${triggerId}`)
+          .send({ name: newTriggerName })
+          .expect(200)
+          .end(function (err, res) {
+            expect(res.body.name).toEqual(newTriggerName);
+            done();
+          });
+      });
+    });
+  });
+
+  describe('Negative', () => {
+    describe(`GET /:mapId`, () => {
+      it(`should respond with status code 500 and proper error msg`, function (done) {
+        request(app)
+          .get('/api/triggers/0')
+          .expect(500)
+          .end(function (err, res) {
+            expect(res.body.message).toEqual("Cast to ObjectId failed for value \"0\" at path \"map\" for model \"Trigger\"");
+            done();
+          });
+      });
+    });
+
+    describe(`POST /:mapId`, () => {
+      it(`should respond with status code 500 and proper error msg`, function (done) {
+        request(app)
+          .post('/api/triggers/0')
+          .expect(500)
+          .end(function (err, res) {
+            expect(res.body.message).toEqual("Trigger validation failed: map: Cast to ObjectID failed for value \"0\" at path \"map\", name: Path `name` is required.");
+            done();
+          });
+      });
+    });
+
+    describe(`DELETE /:mapId/:triggerId`, () => {
+      it(`should respond with status code 500 and proper error msg`, function (done) {
+        request(app)
+          .delete('/api/triggers/0/0')
+          .expect(500)
+          .end(function (err, res) {
+            expect(res.body.message).toEqual("Cast to ObjectId failed for value \"0\" at path \"_id\" for model \"Trigger\"");
+            done();
+          });
+      });
+    });
+    
+    describe(`PUT /:mapId/:triggerId`, () => {
+      it(`should respond with status code 500 and proper error msg`, function (done) {
+        request(app)
+          .put('/api/triggers/0/0')
+          .expect(500)
+          .end(function (err, res) {
+            expect(res.body.message).toEqual("Cast to ObjectId failed for value \"0\" at path \"_id\" for model \"Trigger\"");
+            done();
+          });
+      });
+    });
+  });
+});

--- a/server/api/tests/map-triggers.test.js
+++ b/server/api/tests/map-triggers.test.js
@@ -6,22 +6,22 @@ const {setupDB} = require('./helpers/test-setup')
 const app = 'localhost:3000';
 const mapId = triggersFactory.mapId;
 
-
-
 describe('Map triggers tests', () => {
     let testDataManager;
-
+    let triggerId;
     setupDB();
 
     describe('Positive', () => {
 
         beforeEach(async () => {
-
             testDataManager = new TestDataManager(TriggerModel);
             const triggerCollection = triggersFactory.generateTriggerCollection();
             await testDataManager.generateInitialCollection(
                 triggerCollection
             );
+            const trigger = triggersFactory.generateTriggerDocument();
+            triggerId = trigger._id;
+            await testDataManager.pushToCollectionAndSave(trigger);
         });
 
         afterEach(() => {

--- a/server/api/tests/map-triggers.test.js
+++ b/server/api/tests/map-triggers.test.js
@@ -11,7 +11,7 @@ describe('Map triggers tests', () => {
       request(app)
         .post(`/api/triggers/${mapId}`)
         .send({ name: 'beforeEach trigger' })
-        .end(function (err, res) {
+        .then((res) => {
           triggerId = res.body.id;
           done();
         });
@@ -20,7 +20,7 @@ describe('Map triggers tests', () => {
     afterEach((done) => {
       request(app)
         .delete(`/api/triggers/${mapId}/${triggerId}`)
-        .end(function (err, res) {
+        .then((res) => {
           done();
         });
     })
@@ -30,7 +30,7 @@ describe('Map triggers tests', () => {
         request(app)
           .get(`/api/triggers/${mapId}`)
           .expect(200)
-          .end(function (err, res) {
+          .then((res) => {
             expect(Array.isArray(res.body)).toBe(true);
             done();
           });
@@ -44,7 +44,7 @@ describe('Map triggers tests', () => {
           .post(`/api/triggers/${mapId}`)
           .send({ name: triggerName })
           .expect(200)
-          .end(function (err, res) {
+          .then((res) => {
             expect(res.body.name).toEqual(triggerName);
             done();
           });
@@ -56,7 +56,7 @@ describe('Map triggers tests', () => {
         request(app)
           .delete(`/api/triggers/${mapId}/${triggerId}`)
           .expect(200)
-          .end(function (err, res) {
+          .then((res) => {
             expect('OK');
             done();
           });
@@ -70,7 +70,7 @@ describe('Map triggers tests', () => {
           .put(`/api/triggers/${mapId}/${triggerId}`)
           .send({ name: newTriggerName })
           .expect(200)
-          .end(function (err, res) {
+          .then((res) => {
             expect(res.body.name).toEqual(newTriggerName);
             done();
           });
@@ -84,7 +84,7 @@ describe('Map triggers tests', () => {
         request(app)
           .get('/api/triggers/0')
           .expect(500)
-          .end(function (err, res) {
+          .then((res) => {
             expect(res.body.message).toEqual("Cast to ObjectId failed for value \"0\" at path \"map\" for model \"Trigger\"");
             done();
           });
@@ -96,7 +96,7 @@ describe('Map triggers tests', () => {
         request(app)
           .post('/api/triggers/0')
           .expect(500)
-          .end(function (err, res) {
+          .then((res) => {
             expect(res.body.message).toEqual("Trigger validation failed: map: Cast to ObjectID failed for value \"0\" at path \"map\", name: Path `name` is required.");
             done();
           });
@@ -108,7 +108,7 @@ describe('Map triggers tests', () => {
         request(app)
           .delete('/api/triggers/0/0')
           .expect(500)
-          .end(function (err, res) {
+          .then((res) => {
             expect(res.body.message).toEqual("Cast to ObjectId failed for value \"0\" at path \"_id\" for model \"Trigger\"");
             done();
           });
@@ -120,7 +120,7 @@ describe('Map triggers tests', () => {
         request(app)
           .put('/api/triggers/0/0')
           .expect(500)
-          .end(function (err, res) {
+          .then((res) => {
             expect(res.body.message).toEqual("Cast to ObjectId failed for value \"0\" at path \"_id\" for model \"Trigger\"");
             done();
           });

--- a/server/api/tests/map-triggers.test.js
+++ b/server/api/tests/map-triggers.test.js
@@ -1,28 +1,25 @@
 const request = require('supertest');
+const TriggerModel = require('../../api/models/map-trigger.model');
+const TestDataManager = require('./factories/test-data-manager');
+const triggersFactory = require('./factories/triggers.factory');
 
-const app = require('../../app');
-const mapId = '5d70c6f15556a11f1860bc6e';
-let triggerId = '5d720cabd990b82430dcf60a';
+const app = 'localhost:3000';
+const mapId = triggersFactory.mapId;
 
 describe('Map triggers tests', () => {
+  let testDataManager;
+
   describe('Positive', () => {
 
-    beforeEach((done) => {
-      request(app)
-        .post(`/api/triggers/${mapId}`)
-        .send({ name: 'beforeEach trigger' })
-        .then((res) => {
-          triggerId = res.body.id;
-          done();
-        });
+    beforeEach(() => {
+        testDataManager = new TestDataManager(TriggerModel);
+        return testDataManager.generateInitialCollection(
+          triggersFactory.generateTriggerCollection()
+        );
     })
 
-    afterEach((done) => {
-      request(app)
-        .delete(`/api/triggers/${mapId}/${triggerId}`)
-        .then((res) => {
-          done();
-        });
+    afterEach(() => {
+
     })
 
     describe(`GET /:mapId`, () => {
@@ -114,7 +111,7 @@ describe('Map triggers tests', () => {
           });
       });
     });
-    
+
     describe(`PUT /:mapId/:triggerId`, () => {
       it(`should respond with status code 500 and proper error msg`, function (done) {
         request(app)

--- a/server/api/tests/map-triggers.test.js
+++ b/server/api/tests/map-triggers.test.js
@@ -12,10 +12,13 @@ describe('Map triggers tests', () => {
   describe('Positive', () => {
 
     beforeEach(() => {
-        testDataManager = new TestDataManager(TriggerModel);
-        return testDataManager.generateInitialCollection(
-          triggersFactory.generateTriggerCollection()
-        );
+      /*
+      testDataManager = new TestDataManager(TriggerModel);
+      const triggerCollection = triggersFactory.generateTriggerCollection();
+      return testDataManager.generateInitialCollection(
+        triggerCollection
+      )
+      */
     })
 
     afterEach(() => {

--- a/server/api/tests/map-triggers.test.js
+++ b/server/api/tests/map-triggers.test.js
@@ -2,129 +2,132 @@ const request = require('supertest');
 const TriggerModel = require('../../api/models/map-trigger.model');
 const TestDataManager = require('./factories/test-data-manager');
 const triggersFactory = require('./factories/triggers.factory');
-
+const {setupDB} = require('./helpers/test-setup')
 const app = 'localhost:3000';
 const mapId = triggersFactory.mapId;
 
+
+
 describe('Map triggers tests', () => {
-  let testDataManager;
+    let testDataManager;
 
-  describe('Positive', () => {
+    setupDB();
 
-    beforeEach(() => {
-      /*
-      testDataManager = new TestDataManager(TriggerModel);
-      const triggerCollection = triggersFactory.generateTriggerCollection();
-      return testDataManager.generateInitialCollection(
-        triggerCollection
-      )
-      */
-    })
+    describe('Positive', () => {
 
-    afterEach(() => {
+        beforeEach(async () => {
 
-    })
+            testDataManager = new TestDataManager(TriggerModel);
+            const triggerCollection = triggersFactory.generateTriggerCollection();
+            await testDataManager.generateInitialCollection(
+                triggerCollection
+            );
+        });
 
-    describe(`GET /:mapId`, () => {
-      it(`should respond with a list of triggers`, function (done) {
-        request(app)
-          .get(`/api/triggers/${mapId}`)
-          .expect(200)
-          .then((res) => {
-            expect(Array.isArray(res.body)).toBe(true);
-            done();
-          });
-      });
+        afterEach(() => {
+
+        })
+
+        describe(`GET /:mapId`, () => {
+            it(`should respond with a list of triggers`, function (done) {
+                request(app)
+                    .get(`/api/triggers/${mapId}`)
+                    .expect(200)
+                    .then((res) => {
+                        expect(Array.isArray(res.body)).toBe(true);
+                        done();
+                    });
+            });
+        });
+
+        describe(`POST /:mapId`, () => {
+            it(`should respond with a created trigger`, function (done) {
+                const triggerName = 'test trigger name';
+                request(app)
+                    .post(`/api/triggers/${mapId}`)
+                    .send({name: triggerName})
+                    .expect(200)
+                    .then((res) => {
+                        expect(res.body.name).toEqual(triggerName);
+                        done();
+                    });
+            });
+        });
+
+        describe(`DELETE /:mapId/:triggerId`, () => {
+            it(`should respond with 'OK'`, function (done) {
+                request(app)
+                    .delete(`/api/triggers/${mapId}/${triggerId}`)
+                    .expect(200)
+                    .then((res) => {
+                        expect('OK');
+                        done();
+                    });
+            });
+        });
+
+        describe(`PUT /:mapId/:triggerId`, () => {
+            it(`should respond with an updated trigger`, function (done) {
+                const newTriggerName = 'test trigger name 2';
+                request(app)
+                    .put(`/api/triggers/${mapId}/${triggerId}`)
+                    .send({name: newTriggerName})
+                    .expect(200)
+                    .then((res) => {
+                        expect(res.body.name).toEqual(newTriggerName);
+                        done();
+                    });
+            });
+        });
     });
 
-    describe(`POST /:mapId`, () => {
-      it(`should respond with a created trigger`, function (done) {
-        const triggerName = 'test trigger name';
-        request(app)
-          .post(`/api/triggers/${mapId}`)
-          .send({ name: triggerName })
-          .expect(200)
-          .then((res) => {
-            expect(res.body.name).toEqual(triggerName);
-            done();
-          });
-      });
-    });
+    describe('Negative', () => {
+        describe(`GET /:mapId`, () => {
+            it(`should respond with status code 500 and proper error msg`, function (done) {
+                request(app)
+                    .get('/api/triggers/0')
+                    .expect(500)
+                    .then((res) => {
+                        expect(res.body.message).toEqual("Cast to ObjectId failed for value \"0\" at path \"map\" for model \"Trigger\"");
+                        done();
+                    });
+            });
+        });
 
-    describe(`DELETE /:mapId/:triggerId`, () => {
-      it(`should respond with 'OK'`, function (done) {
-        request(app)
-          .delete(`/api/triggers/${mapId}/${triggerId}`)
-          .expect(200)
-          .then((res) => {
-            expect('OK');
-            done();
-          });
-      });
-    });
+        describe(`POST /:mapId`, () => {
+            it(`should respond with status code 500 and proper error msg`, function (done) {
+                request(app)
+                    .post('/api/triggers/0')
+                    .expect(500)
+                    .then((res) => {
+                        expect(res.body.message).toEqual("Trigger validation failed: map: Cast to ObjectID failed for value \"0\" at path \"map\", name: Path `name` is required.");
+                        done();
+                    });
+            });
+        });
 
-    describe(`PUT /:mapId/:triggerId`, () => {
-      it(`should respond with an updated trigger`, function (done) {
-        const newTriggerName = 'test trigger name 2';
-        request(app)
-          .put(`/api/triggers/${mapId}/${triggerId}`)
-          .send({ name: newTriggerName })
-          .expect(200)
-          .then((res) => {
-            expect(res.body.name).toEqual(newTriggerName);
-            done();
-          });
-      });
-    });
-  });
+        describe(`DELETE /:mapId/:triggerId`, () => {
+            it(`should respond with status code 500 and proper error msg`, function (done) {
+                request(app)
+                    .delete('/api/triggers/0/0')
+                    .expect(500)
+                    .then((res) => {
+                        expect(res.body.message).toEqual("Cast to ObjectId failed for value \"0\" at path \"_id\" for model \"Trigger\"");
+                        done();
+                    });
+            });
+        });
 
-  describe('Negative', () => {
-    describe(`GET /:mapId`, () => {
-      it(`should respond with status code 500 and proper error msg`, function (done) {
-        request(app)
-          .get('/api/triggers/0')
-          .expect(500)
-          .then((res) => {
-            expect(res.body.message).toEqual("Cast to ObjectId failed for value \"0\" at path \"map\" for model \"Trigger\"");
-            done();
-          });
-      });
+        describe(`PUT /:mapId/:triggerId`, () => {
+            it(`should respond with status code 500 and proper error msg`, function (done) {
+                request(app)
+                    .put('/api/triggers/0/0')
+                    .expect(500)
+                    .then((res) => {
+                        expect(res.body.message).toEqual("Cast to ObjectId failed for value \"0\" at path \"_id\" for model \"Trigger\"");
+                        done();
+                    });
+            });
+        });
     });
-
-    describe(`POST /:mapId`, () => {
-      it(`should respond with status code 500 and proper error msg`, function (done) {
-        request(app)
-          .post('/api/triggers/0')
-          .expect(500)
-          .then((res) => {
-            expect(res.body.message).toEqual("Trigger validation failed: map: Cast to ObjectID failed for value \"0\" at path \"map\", name: Path `name` is required.");
-            done();
-          });
-      });
-    });
-
-    describe(`DELETE /:mapId/:triggerId`, () => {
-      it(`should respond with status code 500 and proper error msg`, function (done) {
-        request(app)
-          .delete('/api/triggers/0/0')
-          .expect(500)
-          .then((res) => {
-            expect(res.body.message).toEqual("Cast to ObjectId failed for value \"0\" at path \"_id\" for model \"Trigger\"");
-            done();
-          });
-      });
-    });
-
-    describe(`PUT /:mapId/:triggerId`, () => {
-      it(`should respond with status code 500 and proper error msg`, function (done) {
-        request(app)
-          .put('/api/triggers/0/0')
-          .expect(500)
-          .then((res) => {
-            expect(res.body.message).toEqual("Cast to ObjectId failed for value \"0\" at path \"_id\" for model \"Trigger\"");
-            done();
-          });
-      });
-    });
-  });
 });

--- a/server/config.json
+++ b/server/config.json
@@ -1,1 +1,0 @@
-{"upload_path":"uploads","interval_time":5000,"retries":3,"page_size":15,"dbURI":"mongodb://testUser:xyz123@127.0.0.1:27017/test","serverKey":"33b0f8a55ab2328cf67a8c7dcad4daec"}

--- a/server/config.json
+++ b/server/config.json
@@ -1,1 +1,1 @@
-{"upload_path":"uploads","interval_time":5000,"retries":3,"page_size":15,"dbURI":"mongodb://testUser:xyz123@127.0.0.1:27017/test","serverKey":"2b0c03a5ec603ec65f72f794c9c7be5f"}
+{"upload_path":"uploads","interval_time":5000,"retries":3,"page_size":15,"dbURI":"mongodb://testUser:xyz123@127.0.0.1:27017/test","serverKey":"33b0f8a55ab2328cf67a8c7dcad4daec"}

--- a/server/env/config.json
+++ b/server/env/config.json
@@ -1,7 +1,0 @@
-{
-    "upload_path": "uploads",
-    "interval_time": 5000,
-    "retries": 3,
-    "page_size": 15,
-"dbURI": "mongodb://testUser:xyz123@127.0.0.1:27017/test"
-}

--- a/server/env/config.json.example
+++ b/server/env/config.json.example
@@ -1,0 +1,7 @@
+{
+  "upload_path": "uploads",
+  "interval_time": 5000,
+  "retries": 3,
+  "page_size": 15,
+  "dbURI": "mongodb://testUser:xyz123@127.0.0.1:27017/test"
+}


### PR DESCRIPTION
```PASS api/tests/map-triggers.test.js (10.433s)
  Map triggers tests
    Positive
      GET /:mapId
        √ should respond with a list of triggers (4060ms)
      POST /:mapId
        √ should respond with a created trigger (444ms)
      DELETE /:mapId/:triggerId
        √ should respond with 'OK' (442ms)
      PUT /:mapId/:triggerId
        √ should respond with an updated trigger (442ms)
    Negative
      GET /:mapId
        √ should respond with status code 500 and proper error msg (22ms)
      POST /:mapId
        √ should respond with status code 500 and proper error msg (20ms)
      DELETE /:mapId/:triggerId
        √ should respond with status code 500 and proper error msg (6ms)
      PUT /:mapId/:triggerId
        √ should respond with status code 500 and proper error msg (5ms)

Test Suites: 1 passed, 1 total
Tests:       8 passed, 8 total
Snapshots:   0 total
Time:        10.495s, estimated 11s
Ran all test suites matching /.\\tests\\map-triggers.test.js/i.
```