### PR TITLE
Feature/KAH-12 (Map execution endpoints tests)

### DIFF
--- a/server/api/tests/factories/maps.factory.js
+++ b/server/api/tests/factories/maps.factory.js
@@ -1,4 +1,4 @@
-const {jsf} = require('./jsf.helper');
+const { jsf } = require('./jsf.helper');
 const MapModel = require("../../models/map.model");
 const ProjectModel = require('../../models/project.model');
 
@@ -6,21 +6,32 @@ function getSimpleMapSchema(name) {
     return {
         type: 'object',
         properties: {
-            name
+            _id: {
+                type: 'string',
+                format: 'mongoID'
+            },
+            name: {
+                type: 'string',
+                chance: {
+                    word: {
+                        length: 10
+                    }
+                }
+            }
         },
-        required: ['name'],
+        required: ['_id', 'name'],
     };
 }
 
-function generateSimpleMaps(name) {
+function generateSimpleMap(name) {
     return jsf.generate(getSimpleMapSchema(name));
 }
 
 async function createMap(projectId, index, mapName) {
-    const generatedMap = generateSimpleMaps(mapName);
+    const generatedMap = generateSimpleMap(mapName);
     try {
         const map = await MapModel.create(generatedMap);
-        await ProjectModel.findByIdAndUpdate({_id: projectId}, {$push: {maps: map.id}});
+        await ProjectModel.findByIdAndUpdate({ _id: projectId }, { $push: { maps: map.id } });
         return map;
     } catch (err) {
         throw err;
@@ -29,5 +40,5 @@ async function createMap(projectId, index, mapName) {
 
 module.exports = {
     createMap,
-    generateSimpleMaps
+    generateSimpleMap: generateSimpleMap
 };

--- a/server/api/tests/factories/maps.factory.js
+++ b/server/api/tests/factories/maps.factory.js
@@ -2,7 +2,7 @@ const { jsf } = require('./jsf.helper');
 const MapModel = require("../../models/map.model");
 const ProjectModel = require('../../models/project.model');
 
-function getSimpleMapSchema(name) {
+function getSimpleMapSchema() {
     return {
         type: 'object',
         properties: {
@@ -23,12 +23,13 @@ function getSimpleMapSchema(name) {
     };
 }
 
-function generateSimpleMap(name) {
-    return jsf.generate(getSimpleMapSchema(name));
+function generateSimpleMap() {
+    return jsf.generate(getSimpleMapSchema());
 }
 
 async function createMap(projectId, index, mapName) {
-    const generatedMap = generateSimpleMap(mapName);
+    const generatedMap = generateSimpleMap();
+    generatedMap.name = mapName;
     try {
         const map = await MapModel.create(generatedMap);
         await ProjectModel.findByIdAndUpdate({ _id: projectId }, { $push: { maps: map.id } });

--- a/server/api/tests/factories/triggers.factory.js
+++ b/server/api/tests/factories/triggers.factory.js
@@ -59,15 +59,27 @@ const triggerSchema = {
         active: { type: 'boolean', faker: 'random.boolean' },
         plugin: {
             type: 'string',
-            faker: 'random.word'
+            chance: {
+                word: {
+                    length: 10
+                }
+            }
         },
         method: {
             type: 'string',
-            faker: 'random.word'
+            chance: {
+                word: {
+                    length: 10
+                }
+            }
         },
         configuration: {
             type: 'string',
-            faker: 'random.word'
+            chance: {
+                word: {
+                    length: 10
+                }
+            }
         },
         params: {
             $ref: actionParamsSchema

--- a/server/api/tests/map-execution.test.js
+++ b/server/api/tests/map-execution.test.js
@@ -2,7 +2,7 @@ const request = require('supertest');
 const MapModel = require('../../api/models/map.model');
 const TestDataManager = require('./factories/test-data-manager');
 const mapsFactory = require('./factories/maps.factory');
-const {setupDB} = require('./helpers/test-setup')
+const { setupDB } = require('./helpers/test-setup')
 const app = 'localhost:3000';
 
 describe('Map execution tests', () => {
@@ -19,57 +19,75 @@ describe('Map execution tests', () => {
 
     // router.post("/:id/execute", mapController.execute);
     describe('POST /api/maps/:mapId/execute', () => {
-        it(`should handle lack of map`, ()=> {
+        it(`should handle lack of map`, () => {
             const mapId = mapsFactory.generateSimpleMap()._id;
             return request(app)
                 .post(`/api/maps/${mapId}/execute`)
                 .expect(500)
-                .then(({text}) => {
+                .then(({ text }) => {
                     expect(text).toBe('Couldn\'t find map');
                 })
         });
 
-        it(`should handle lack of map structure`, ()=> {
+        it(`should handle lack of map structure`, () => {
             return request(app)
                 .post(`/api/maps/${mapId}/execute`)
                 .expect(500)
-                .then(({text}) => {
+                .then(({ text }) => {
                     expect(text).toBe('No structure found.');
                 })
         });
     });
 
     // router.post("/:id/execute/:structure", mapController.execute);
-    // NOTICE - THIS ROUTE IS NOT USED IN THE FRONTEND (-> KAH-37)
+    // NOTICE - THIS ROUTE IS NOT USED IN THE FRONTEND (KAH-37)
     describe('POST /api/maps/:mapId/execute/:structureId', () => {
-        it(`should handle lack of map`, ()=> {
+        it(`should handle lack of map`, () => {
             const mapId = mapsFactory.generateSimpleMap()._id;
+            const structureId = mapId;
             return request(app)
-                .post(`/api/maps/${mapId}/execute/${mapId}`)
+                .post(`/api/maps/${mapId}/execute/${structureId}`)
                 .expect(500)
-                .then(({text}) => {
+                .then(({ text }) => {
                     expect(text).toBe('Couldn\'t find map');
                 })
         });
 
-        it(`should handle lack of map structure`, ()=> {
+        it(`should handle lack of map structure`, () => {
+            const structureId = mapId;
             return request(app)
-                .post(`/api/maps/${mapId}/execute/${mapId}`)
+                .post(`/api/maps/${mapId}/execute/${structureId}`)
                 .expect(500)
-                .then(({text}) => {
+                .then(({ text }) => {
                     expect(text).toBe('No structure found.');
                 })
         });
     });
 
     // router.get("/:id/stop-execution", mapController.stopExecution);
+    // NOTICE - THIS ROUTE IS NOT USED IN THE FRONTEND (KAH-38)
     describe('GET /api/maps/:mapId/stop-execution', () => {
-    
+        it(`should return {} for no executions stopped`, () => {
+            return request(app)
+                .get(`/api/maps/${mapId}/stop-execution`)
+                .expect(200)
+                .then(({ body }) => {
+                    expect(body).toEqual({});
+                });
+        });
     });
 
     // router.get("/:id/stop-execution/:runId", mapController.stopExecution);
     describe('GET /api/maps/:mapId/stop-execution/:runId', () => {
-    
+        it(`should return {} for no executions stopped`, () => {
+            const random = Math.floor(Math.random() * 10 + 1);
+            return request(app)
+                .get(`/api/maps/${mapId}/stop-execution/${random}`)
+                .expect(200)
+                .then(({ body }) => {
+                    expect(body).toEqual({});
+                });
+        });
     });
 
     // router.post("/:id/cancel-pending", mapController.cancelPending);
@@ -77,11 +95,11 @@ describe('Map execution tests', () => {
 
     // router.get("/currentruns", mapController.currentRuns);
     describe('POST /api/maps/currentRuns', () => {
-        it(`should return {} for no current runs`, ()=> {
+        it(`should return {} for no current runs`, () => {
             return request(app)
                 .post(`/api/maps/currentRuns`)
                 .expect(200)
-                .then(({body}) => {
+                .then(({ body }) => {
                     expect(body).toEqual({});
                 })
         });

--- a/server/api/tests/map-execution.test.js
+++ b/server/api/tests/map-execution.test.js
@@ -41,6 +41,18 @@ describe('Map execution tests', () => {
         });
     });
 
+    describe('POST /api/maps/:mapId/execute', () => {
+        it(`should handle lack of map`, ()=> {
+            const mapId = mapsFactory.generateSimpleMap()._id;
+            return request(app)
+                .post(`/api/maps/${mapId}/execute`)
+                .expect(500)
+                .then(({text}) => {
+                    expect(text).toBe('Couldn\'t find map');
+                })
+        });
+    });
+
     describe('POST /api/maps/currentRuns', () => {
         it(`should return {} for no current runs`, ()=> {
             return request(app)
@@ -51,5 +63,8 @@ describe('Map execution tests', () => {
                 })
         });
     });
+
+    // TODO: cancel pending will not reject / respond with 500 because of the bug
+    // router.post("/:id/cancel-pending", mapController.cancelPending);
 
 });

--- a/server/api/tests/map-execution.test.js
+++ b/server/api/tests/map-execution.test.js
@@ -106,7 +106,7 @@ describe('Map execution tests', () => {
     // router.get("/:id/stop-execution", mapController.stopExecution);
     // NOTICE - THIS ROUTE IS NOT USED IN THE FRONTEND (KAH-38)
     describe('GET /api/maps/:mapId/stop-execution', () => {
-        it(`should return {} for no executions stopped`, () => {
+        it(`should return {}`, () => {
             return request(app)
                 .get(`/api/maps/${mapId}/stop-execution`)
                 .expect(200)
@@ -117,8 +117,9 @@ describe('Map execution tests', () => {
     });
 
     // router.get("/:id/stop-execution/:runId", mapController.stopExecution);
+    // NOTICE: does this route always return 200?
     describe('GET /api/maps/:mapId/stop-execution/:runId', () => {
-        it(`should return {} for no executions stopped`, () => {
+        it(`should return {}`, () => {
             const random = Math.floor(Math.random() * 10 + 1);
             return request(app)
                 .get(`/api/maps/${mapId}/stop-execution/${random}`)
@@ -130,9 +131,17 @@ describe('Map execution tests', () => {
     });
 
     // router.post("/:id/cancel-pending", mapController.cancelPending);
-    //  TODO: cancel pending will not reject / respond with 500 because of the bug (KAH-36)
+    // NOTICE: cancel pending will not reject / respond with 500 because of the bug (KAH-36)
+    // NOTICE: not possible to test this route, because the state is kept in memory of the node process
+    /*
+    describe('POST /api/maps/:id/cancel-pending', () => {
+    });
+    */
 
     // router.get("/currentruns", mapController.currentRuns);
+    // NOTICE: not able to test a case with existing current runs
+    // because, the same as with pending executions, the ongoing executions are kept
+    // in memory instead of the database
     describe('GET /api/maps/currentruns', () => {
         it(`should return {} for no current runs`, () => {
             return request(app)

--- a/server/api/tests/map-execution.test.js
+++ b/server/api/tests/map-execution.test.js
@@ -1,0 +1,44 @@
+
+/*
+router.post("/:id/execute", mapController.execute);
+router.post("/:id/execute/:structure", mapController.execute);
+router.get("/:id/stop-execution", mapController.stopExecution);
+router.get("/:id/stop-execution/:runId", mapController.stopExecution);
+router.post("/:id/cancel-pending", mapController.cancelPending);
+router.get("/currentruns", mapController.currentRuns);
+
+/api/maps
+
+*/
+
+const request = require('supertest');
+const MapModel = require('../../api/models/map.model');
+const TestDataManager = require('./factories/test-data-manager');
+const mapsFactory = require('./factories/maps.factory');
+const {setupDB} = require('./helpers/test-setup')
+const app = 'localhost:3000';
+
+describe('Map execution tests', () => {
+    let testDataManager;
+    setupDB();
+
+    beforeEach(async () => {
+        testDataManager = new TestDataManager(MapModel);
+        const mapCollection = mapsFactory.generateSimpleMaps();
+        await testDataManager.generateInitialCollection(
+            mapCollection
+        );
+        const trigger = mapsFactory.createMap();
+        triggerId = trigger._id;
+        await testDataManager.pushToCollectionAndSave(trigger);
+    });
+
+    describe('Positive', () => {
+
+    });
+
+    describe('Negative', () => {
+
+    });
+
+});

--- a/server/api/tests/map-execution.test.js
+++ b/server/api/tests/map-execution.test.js
@@ -41,4 +41,15 @@ describe('Map execution tests', () => {
         });
     });
 
+    describe('POST /api/maps/currentRuns', () => {
+        it(`should return {} for no current runs`, ()=> {
+            return request(app)
+                .post(`/api/maps/currentRuns`)
+                .expect(200)
+                .then(({body}) => {
+                    expect(body).toEqual({});
+                })
+        });
+    });
+
 });

--- a/server/api/tests/map-execution.test.js
+++ b/server/api/tests/map-execution.test.js
@@ -20,25 +20,25 @@ const app = 'localhost:3000';
 
 describe('Map execution tests', () => {
     let testDataManager;
+    let mapId;
     setupDB();
 
     beforeEach(async () => {
         testDataManager = new TestDataManager(MapModel);
-        const mapCollection = mapsFactory.generateSimpleMaps();
-        await testDataManager.generateInitialCollection(
-            mapCollection
-        );
-        const trigger = mapsFactory.createMap();
-        triggerId = trigger._id;
-        await testDataManager.pushToCollectionAndSave(trigger);
+        const map = mapsFactory.generateSimpleMap();
+        await testDataManager.generateInitialCollection(map);
+        mapId = map._id;
     });
 
-    describe('Positive', () => {
-
-    });
-
-    describe('Negative', () => {
-
+    describe('POST /api/maps/:mapId/execute', () => {
+        it(`should handle lack of map structure`, ()=> {
+            return request(app)
+                .post(`/api/maps/${mapId}/execute`)
+                .expect(500)
+                .then(({text}) => {
+                    expect(text).toBe('No structure found.');
+                })
+        });
     });
 
 });

--- a/server/api/tests/map-execution.test.js
+++ b/server/api/tests/map-execution.test.js
@@ -121,17 +121,17 @@ describe('Map execution tests', () => {
                 })
         });
 
-        it(`should handle no agents alive when trigger is 'started manually by user'`, async () => {
+        it(`should handle no agents alive when trigger is 'started manually by user'`, () => {
             return request(app)
                 .post(`/api/maps/${mapId}/execute/${structureId}`)
                 .send({ trigger: "Started manually by user" })
                 .expect(500)
                 .then((res) => {
                     expect(res.text).toBe('No agents alive');
-                })
+                });
         });
 
-        it(`should respond with new runId and current mapId`, async () => {
+        it(`should respond with new runId and current mapId`, () => {
             return request(app)
                 .post(`/api/maps/${mapId}/execute/${structureId}`)
                 .expect(200)

--- a/server/api/tests/map-execution.test.js
+++ b/server/api/tests/map-execution.test.js
@@ -37,6 +37,16 @@ describe('Map execution tests', () => {
                     expect(text).toBe('No structure found.');
                 })
         });
+
+        it(`should not execute an archived map`, async () => {
+            await MapModel.findByIdAndUpdate(mapId, {archived: true});
+            return request(app)
+                .post(`/api/maps/${mapId}/execute`)
+                .expect(500)
+                .then(({ text }) => {
+                    expect(text).toBe('Can\'t execute archived map');
+                })
+        });
     });
 
     // router.post("/:id/execute/:structure", mapController.execute);

--- a/server/api/tests/map-execution.test.js
+++ b/server/api/tests/map-execution.test.js
@@ -1,16 +1,3 @@
-
-/*
-router.post("/:id/execute", mapController.execute);
-router.post("/:id/execute/:structure", mapController.execute);
-router.get("/:id/stop-execution", mapController.stopExecution);
-router.get("/:id/stop-execution/:runId", mapController.stopExecution);
-router.post("/:id/cancel-pending", mapController.cancelPending);
-router.get("/currentruns", mapController.currentRuns);
-
-/api/maps
-
-*/
-
 const request = require('supertest');
 const MapModel = require('../../api/models/map.model');
 const TestDataManager = require('./factories/test-data-manager');
@@ -30,17 +17,7 @@ describe('Map execution tests', () => {
         mapId = map._id;
     });
 
-    describe('POST /api/maps/:mapId/execute', () => {
-        it(`should handle lack of map structure`, ()=> {
-            return request(app)
-                .post(`/api/maps/${mapId}/execute`)
-                .expect(500)
-                .then(({text}) => {
-                    expect(text).toBe('No structure found.');
-                })
-        });
-    });
-
+    // router.post("/:id/execute", mapController.execute);
     describe('POST /api/maps/:mapId/execute', () => {
         it(`should handle lack of map`, ()=> {
             const mapId = mapsFactory.generateSimpleMap()._id;
@@ -51,8 +28,54 @@ describe('Map execution tests', () => {
                     expect(text).toBe('Couldn\'t find map');
                 })
         });
+
+        it(`should handle lack of map structure`, ()=> {
+            return request(app)
+                .post(`/api/maps/${mapId}/execute`)
+                .expect(500)
+                .then(({text}) => {
+                    expect(text).toBe('No structure found.');
+                })
+        });
     });
 
+    // router.post("/:id/execute/:structure", mapController.execute);
+    // NOTICE - THIS ROUTE IS NOT USED IN THE FRONTEND (-> KAH-37)
+    describe('POST /api/maps/:mapId/execute/:structureId', () => {
+        it(`should handle lack of map`, ()=> {
+            const mapId = mapsFactory.generateSimpleMap()._id;
+            return request(app)
+                .post(`/api/maps/${mapId}/execute/${mapId}`)
+                .expect(500)
+                .then(({text}) => {
+                    expect(text).toBe('Couldn\'t find map');
+                })
+        });
+
+        it(`should handle lack of map structure`, ()=> {
+            return request(app)
+                .post(`/api/maps/${mapId}/execute/${mapId}`)
+                .expect(500)
+                .then(({text}) => {
+                    expect(text).toBe('No structure found.');
+                })
+        });
+    });
+
+    // router.get("/:id/stop-execution", mapController.stopExecution);
+    describe('GET /api/maps/:mapId/stop-execution', () => {
+    
+    });
+
+    // router.get("/:id/stop-execution/:runId", mapController.stopExecution);
+    describe('GET /api/maps/:mapId/stop-execution/:runId', () => {
+    
+    });
+
+    // router.post("/:id/cancel-pending", mapController.cancelPending);
+    //  TODO: cancel pending will not reject / respond with 500 because of the bug (KAH-36)
+
+    // router.get("/currentruns", mapController.currentRuns);
     describe('POST /api/maps/currentRuns', () => {
         it(`should return {} for no current runs`, ()=> {
             return request(app)
@@ -63,8 +86,4 @@ describe('Map execution tests', () => {
                 })
         });
     });
-
-    // TODO: cancel pending will not reject / respond with 500 because of the bug
-    // router.post("/:id/cancel-pending", mapController.cancelPending);
-
 });


### PR DESCRIPTION
```
Map execution tests
    POST /api/maps/:mapId/execute
      √ should handle lack of map (1223ms)
      √ should handle lack of map structure (1260ms)
      √ should not execute an archived map (1260ms)
      √ should handle no agents alive when trigger is 'started manually by user' (1417ms)
      √ should respond with new runId and current mapId (1728ms)
    POST /api/maps/:mapId/execute/:structureId
      √ should handle lack of map (1242ms)
      √ should handle lack of map structure (1367ms)
      √ should not execute an archived map (2225ms)
      √ should handle no agents alive when trigger is 'started manually by user' (1419ms)
      √ should respond with new runId and current mapId (1679ms)
    GET /api/maps/:mapId/stop-execution
      √ should return {} (973ms)
    GET /api/maps/:mapId/stop-execution/:runId
      √ should return {} (979ms)
    GET /api/maps/currentruns
      √ should return {} for no current runs (989ms)

Test Suites: 1 passed, 1 total  
Tests:       13 passed, 13 total
Snapshots:   0 total
Time:        25.599s, estimated 27s
```